### PR TITLE
Add a new API set_node_coordinates() to RRGraphBuilder

### DIFF
--- a/vpr/src/device/rr_graph_builder.cpp
+++ b/vpr/src/device/rr_graph_builder.cpp
@@ -50,3 +50,7 @@ void RRGraphBuilder::add_node_to_all_locs(RRNodeId node) {
 void RRGraphBuilder::clear() {
     node_lookup_.clear();
 }
+
+void RRGraphBuilder::set_node_coordinates(RRNodeId id, short x1, short y1, short x2, short y2) {
+    node_storage_.set_node_coordinates(id, x1, y1, x2, y2);
+}

--- a/vpr/src/device/rr_graph_builder.h
+++ b/vpr/src/device/rr_graph_builder.h
@@ -55,6 +55,9 @@ class RRGraphBuilder {
     /** @brief Clear all the underlying data storage */
     void clear();
 
+    /** @brief Set the node coordinate */
+    void set_node_coordinates(RRNodeId id, short x1, short y1, short x2, short y2);
+
     /* -- Internal data storage -- */
   private:
     /* TODO: When the refactoring effort finishes, 

--- a/vpr/src/route/clock_connection_builders.cpp
+++ b/vpr/src/route/clock_connection_builders.cpp
@@ -92,6 +92,7 @@ void RoutingToClockConnection::create_switches(const ClockRRGraphBuilder& clock_
 RRNodeId RoutingToClockConnection::create_virtual_clock_network_sink_node(int x, int y) {
     auto& device_ctx = g_vpr_ctx.mutable_device();
     auto& rr_graph = device_ctx.rr_nodes;
+    auto& rr_graph_builder = device_ctx.rr_graph_builder;
     auto& node_lookup = device_ctx.rr_graph_builder.node_lookup();
     rr_graph.emplace_back();
     RRNodeId node_index = RRNodeId(rr_graph.size() - 1);
@@ -106,7 +107,7 @@ RRNodeId RoutingToClockConnection::create_virtual_clock_network_sink_node(int x,
     int ptc = max_ptc + 1;
 
     rr_graph.set_node_ptc_num(node_index, ptc);
-    rr_graph.set_node_coordinates(node_index, x, y, x, y);
+    rr_graph_builder.set_node_coordinates(node_index, x, y, x, y);
     rr_graph.set_node_capacity(node_index, 1);
     rr_graph.set_node_cost_index(node_index, SINK_COST_INDEX);
     rr_graph.set_node_type(node_index, SINK);

--- a/vpr/src/route/clock_network_builders.cpp
+++ b/vpr/src/route/clock_network_builders.cpp
@@ -317,8 +317,9 @@ int ClockRib::create_chanx_wire(int x_start,
     rr_nodes->emplace_back();
     auto node_index = rr_nodes->size() - 1;
     auto node = rr_nodes->back();
+    RRNodeId chanx_node = RRNodeId(node_index);
 
-    node.set_coordinates(x_start, y, x_end, y);
+    rr_graph_builder.set_node_coordinates(chanx_node,x_start, y, x_end, y);
     node.set_type(CHANX);
     node.set_capacity(1);
     node.set_track_num(ptc_num);
@@ -345,7 +346,7 @@ int ClockRib::create_chanx_wire(int x_start,
 
     /* Add the node to spatial lookup */
     auto& rr_graph = (*rr_nodes);
-    RRNodeId chanx_node = RRNodeId(node_index);
+    
     /* TODO: Will replace these codes with an API add_node_to_all_locs() of RRGraphBuilder */
     for (int ix = rr_graph.node_xlow(chanx_node); ix <= rr_graph.node_xhigh(chanx_node); ++ix) {
         for (int iy = rr_graph.node_ylow(chanx_node); iy <= rr_graph.node_yhigh(chanx_node); ++iy) {
@@ -623,8 +624,9 @@ int ClockSpine::create_chany_wire(int y_start,
     rr_nodes->emplace_back();
     auto node_index = rr_nodes->size() - 1;
     auto node = rr_nodes->back();
+    RRNodeId chany_node = RRNodeId(node_index);
 
-    node.set_coordinates(x, y_start, x, y_end);
+    rr_graph_builder.set_node_coordinates(chany_node, x, y_start, x, y_end);
     node.set_type(CHANY);
     node.set_capacity(1);
     node.set_track_num(ptc_num);
@@ -651,7 +653,7 @@ int ClockSpine::create_chany_wire(int y_start,
 
     /* Add the node to spatial lookup */
     auto& rr_graph = (*rr_nodes);
-    RRNodeId chany_node = RRNodeId(node_index);
+    
     /* TODO: Will replace these codes with an API add_node_to_all_locs() of RRGraphBuilder */
     for (int ix = rr_graph.node_xlow(chany_node); ix <= rr_graph.node_xhigh(chany_node); ++ix) {
         for (int iy = rr_graph.node_ylow(chany_node); iy <= rr_graph.node_yhigh(chany_node); ++iy) {

--- a/vpr/src/route/clock_network_builders.cpp
+++ b/vpr/src/route/clock_network_builders.cpp
@@ -346,7 +346,7 @@ int ClockRib::create_chanx_wire(int x_start,
 
     /* Add the node to spatial lookup */
     auto& rr_graph = (*rr_nodes);
-    
+
     /* TODO: Will replace these codes with an API add_node_to_all_locs() of RRGraphBuilder */
     for (int ix = rr_graph.node_xlow(chanx_node); ix <= rr_graph.node_xhigh(chanx_node); ++ix) {
         for (int iy = rr_graph.node_ylow(chanx_node); iy <= rr_graph.node_yhigh(chanx_node); ++iy) {

--- a/vpr/src/route/clock_network_builders.cpp
+++ b/vpr/src/route/clock_network_builders.cpp
@@ -319,7 +319,7 @@ int ClockRib::create_chanx_wire(int x_start,
     auto node = rr_nodes->back();
     RRNodeId chanx_node = RRNodeId(node_index);
 
-    rr_graph_builder.set_node_coordinates(chanx_node,x_start, y, x_end, y);
+    rr_graph_builder.set_node_coordinates(chanx_node, x_start, y, x_end, y);
     node.set_type(CHANX);
     node.set_capacity(1);
     node.set_track_num(ptc_num);
@@ -653,7 +653,7 @@ int ClockSpine::create_chany_wire(int y_start,
 
     /* Add the node to spatial lookup */
     auto& rr_graph = (*rr_nodes);
-    
+
     /* TODO: Will replace these codes with an API add_node_to_all_locs() of RRGraphBuilder */
     for (int ix = rr_graph.node_xlow(chany_node); ix <= rr_graph.node_xhigh(chany_node); ++ix) {
         for (int iy = rr_graph.node_ylow(chany_node); iy <= rr_graph.node_yhigh(chany_node); ++iy) {

--- a/vpr/src/route/rr_graph.cpp
+++ b/vpr/src/route/rr_graph.cpp
@@ -1429,7 +1429,7 @@ static void build_rr_sinks_sources(RRGraphBuilder& rr_graph_builder,
 
         /* Things common to both SOURCEs and SINKs.   */
         L_rr_node.set_node_capacity(inode, class_inf[iclass].num_pins);
-        L_rr_node.set_node_coordinates(inode, i, j, i + type->width - 1, j + type->height - 1);
+        rr_graph_builder.set_node_coordinates(inode, i, j, i + type->width - 1, j + type->height - 1);
         float R = 0.;
         float C = 0.;
         L_rr_node.set_node_rc_index(inode, find_create_rr_rc_data(R, C));
@@ -1488,7 +1488,7 @@ static void build_rr_sinks_sources(RRGraphBuilder& rr_graph_builder,
                             //For those pins located on multiple sides, we save the rr node index
                             //for the pin on all sides at which it exists
                             //As such, multipler driver problem can be avoided.
-                            L_rr_node.set_node_coordinates(inode, i + width_offset, j + height_offset, i + width_offset, j + height_offset);
+                            rr_graph_builder.set_node_coordinates(inode, i + width_offset, j + height_offset, i + width_offset, j + height_offset);
                             L_rr_node.add_node_side(inode, side);
 
                             // Sanity check
@@ -1660,10 +1660,10 @@ static void build_rr_chan(RRGraphBuilder& rr_graph_builder,
         L_rr_node.set_node_capacity(node, 1); /* GLOBAL routing handled elsewhere */
 
         if (chan_type == CHANX) {
-            L_rr_node.set_node_coordinates(node, start, y_coord, end, y_coord);
+            rr_graph_builder.set_node_coordinates(node, start, y_coord, end, y_coord);
         } else {
             VTR_ASSERT(chan_type == CHANY);
-            L_rr_node.set_node_coordinates(node, x_coord, start, x_coord, end);
+            rr_graph_builder.set_node_coordinates(node, x_coord, start, x_coord, end);
         }
 
         int length = end - start + 1;

--- a/vpr/src/route/rr_graph_uxsdcxx_serializer.h
+++ b/vpr/src/route/rr_graph_uxsdcxx_serializer.h
@@ -601,8 +601,9 @@ class RrGraphSerializer final : public uxsd::RrGraphBase<RrGraphContextTypes> {
 
     inline int init_node_loc(int& inode, int ptc, int xhigh, int xlow, int yhigh, int ylow) final {
         auto node = (*rr_nodes_)[inode];
+        RRNodeId node_id = node.id();
 
-        node.set_coordinates(xlow, ylow, xhigh, yhigh);
+        rr_graph_builder_->set_node_coordinates(node_id, xlow, ylow, xhigh, yhigh);
         node.set_ptc_num(ptc);
         return inode;
     }

--- a/vpr/src/route/rr_node.cpp
+++ b/vpr/src/route/rr_node.cpp
@@ -55,14 +55,6 @@ void t_rr_node::set_type(t_rr_type new_type) {
     storage_->set_node_type(id_, new_type);
 }
 
-/*
- * Pass in two coordinate variables describing location of node.
- * They do not have to be in any particular order.
- */
-void t_rr_node::set_coordinates(short x1, short y1, short x2, short y2) {
-    storage_->set_node_coordinates(id_, x1, y1, x2, y2);
-}
-
 void t_rr_node::set_ptc_num(short new_ptc_num) {
     storage_->set_node_ptc_num(id_, new_ptc_num);
 }

--- a/vpr/src/route/rr_node.h
+++ b/vpr/src/route/rr_node.h
@@ -110,8 +110,6 @@ class t_rr_node {
   public: //Mutators
     void set_type(t_rr_type new_type);
 
-    void set_coordinates(short x1, short y1, short x2, short y2);
-
     void set_capacity(short);
 
     void set_ptc_num(short);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR focuses on updating routing resource graph builder functions, where we use the refactored data structure `RRGraphBuilder` to shadow the discreted data structure `rr_graph_storage`.
This PR aims to fully deprecate the direct use of the legacy API `set_coordinates()` from `rr_node` data structure.

After this PR, the `set_coordinates` API is fully deprecated and the `set_node_coordinates` from the refactored data structure `RRGraphBuilder` is the only way to use.

Checklist:

- [x] Removed the legacy API `set_coordinates()` from `rr_node.cpp` and `rr_node.h`
- [x] Added new APIs `set_node_coordinates` to data structures `RRGraphBuilder`, whose comments are Doxygen compatible
- [x] Replaced all the use of `set_coordinates()` in builder functions by `set_node_coordinates()`

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This pull request is a follow-up PR on the routing resource graph refactoring effort [ #1805 ](https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/1805)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This PR is the continuation to the refactoring effort with a focus on shadowing the `rr_graph_storage` APIs in `RRGraphBuilder` data structure.
This  PR reworks the set_node_coordinates() API among the other APIs in https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/1847

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] All vtr basic and strong tests are passing.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
